### PR TITLE
Add application/mp4 to registry

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,7 +143,8 @@
           <tr>
             <td>
               audio/mp4<br>
-              video/mp4
+              video/mp4<br>
+              application/mp4
             </td>
             <td><a def-id="byte-stream-format-registry-isobmff"></a> [[!MSE-FORMAT-ISOBMFF]]</td>
             <td>false</td>


### PR DESCRIPTION
PR copied over from https://github.com/w3c/media-source/pull/257
See discussion in original issue https://github.com/w3c/media-source/issues/197
Also see companion PR against ISO BMFF Byte Stream Format spec: https://github.com/w3c/mse-byte-stream-format-isobmff/pull/1

Original author:
+@davemevans


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/mse-byte-stream-format-registry/pull/1.html" title="Last updated on Nov 24, 2020, 1:35 PM UTC (afa111c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mse-byte-stream-format-registry/1/75bec22...afa111c.html" title="Last updated on Nov 24, 2020, 1:35 PM UTC (afa111c)">Diff</a>