### PR TITLE
Refine registry definition

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,12 +80,13 @@
             {{SourceBuffer}} when handling the byte stream format.</li>
         <li>Each entry MUST include a link that references a publically available specification. It is recommended that such a specification be made available
           without cost (other than reasonable shipping and handling if not available by online means).</li>
-        <li>Each entry MUST comply with all requirements outlined in the <a data-cite="media-source#byte-stream-formats">Byte Stream Formats section</a> of the [[[MEDIA-SOURCE]]] specification [[MEDIA-SOURCE]].</li>
+        <li>The referenced specification for each entry MUST comply with all requirements outlined in the <a data-cite="media-source#byte-stream-formats">Byte Stream Formats section</a> of the [[[MEDIA-SOURCE]]] specification [[MEDIA-SOURCE]].</li>
         <li>Candidate entries MUST be announced on <a href="mailto:public-html-media@w3.org">public-html-media@w3.org</a> (<a href="mailto:public-html-media-request@w3.org">subscribe</a>,
           <a href="http://lists.w3.org/Archives/Public/public-html-media/">archives</a>) so they can be discussed and evaluated for compliance before being added to the
-          registry.</li>
+          registry. The Media Working Group may seek expertise from outside the Working Group as part of its evaluation, e.g., from the codec specification editors or relevant standards group. If the Media Working Group reaches consensus to accept the candidate, a pull request should be drafted (either by editors or by the party requesting the candidate registration) to register the candidate. The registry editors will review and merge the pull request.</li>
+        <li>If a registration fails to satisfy a mandatory requirement specified above, then it MAY be removed from the registry (without prejudice). Existing entries cannot be deleted or deprecated otherwise.</li>
+        <li>Existing entries MAY be changed after being published through the same process as candidate entries. Possible changes include modification of the link to the publically available specification.</li>
       </ol>
-      <p>If a registration fails to satisfy a mandatory requirement specified above, then it MAY be removed from the registry (without prejudice).
     </section>
 
     <section id="registry">


### PR DESCRIPTION
This extends the registry definition to meet Process requirements for specs on the Registry Track:
https://www.w3.org/2023/Process-20231103/#reg-def

Updates:
- Clarify that what needs to comply with byte stream formats requirements is the referenced specification, not the registry entry itself
- Better identify the Media Working Group as custodian of the registry
- Detail the process by which registry entries may be added
- Complete the policy for changes to existing entries

The text reuses wording from other registries published by the Media WG.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/mse-byte-stream-format-registry/pull/4.html" title="Last updated on Dec 19, 2023, 10:08 AM UTC (f5b7ec1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mse-byte-stream-format-registry/4/1e22f15...f5b7ec1.html" title="Last updated on Dec 19, 2023, 10:08 AM UTC (f5b7ec1)">Diff</a>