### PR TITLE
Refresh list of editors and SOTD

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,12 +18,16 @@
       // editors, add as many as you like
       // only "name" is required
       editors:  [
-          { name: "Matthew Wolenetz",  url: "", mailto: "wolenetz@google.com",
-            company: "Google Inc.", companyURL: "https://www.google.com/", w3cid: "76912" },
-          { name: "Jerry Smith", url: "",
-            company: "Microsoft Corporation", companyURL: "https://www.microsoft.com/" },
-          { name: "Aaron Colwell (until April 2015)",  url: "",
-           company: "Google Inc.", companyURL: "https://www.google.com/" },
+        { name: "Matthew Wolenetz", mailto: "matt.wolenetz@gmail.com",
+          company: "W3C Invited Expert",
+          w3cid: "148095" },
+      ],
+
+      formerEditors: [
+        { name: "Jerry Smith", note: "Until September 2017", url: "",
+          company: "Microsoft Corporation", companyURL: "https://www.microsoft.com/" },
+        { name: "Aaron Colwell", note: "Until April 2015",  url: "",
+          company: "Google Inc.", companyURL: "https://www.google.com/" },
       ],
 
       group: "media",
@@ -50,8 +54,7 @@
 
     <section id="sotd">
       <p>The working group maintains <a href="https://github.com/w3c/mse-byte-stream-format-registry/issues">a list of all bug reports that the editors have not yet tried to address</a>;
-      there may also be related open bugs in the <a href="https://github.com/w3c/media-source">GitHub repository</a>.</p>
-      <p>Implementors should be aware that this specification is not stable. <strong>Implementors who are not taking part in the discussions are likely to find the specification changing out from under them in incompatible ways.</strong> Vendors interested in implementing this specification before it eventually reaches the Candidate Recommendation stage should join the mailing list mentioned below and take part in the discussions.</p>
+      there may also be related open bugs in the <a href="https://github.com/w3c/media-source">GitHub repository</a> of the [[[MEDIA SOURCE]]] specification.</p>
     </section>
 
     <section id="purpose">


### PR DESCRIPTION
Updates needed so that the Media WG can start publishing updates again:
- Moved editors who are no longer in the group to the list of former editors.
- Dropped the paragraph about unstability before Candidate Recommendation stage from the Status of This Document section, as it does not apply to a Note.
- Completed the link to the GitHub repository of MSE.

Same updates as in https://github.com/w3c/mse-byte-stream-format-isobmff/pull/13


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/mse-byte-stream-format-registry/pull/5.html" title="Last updated on Dec 19, 2023, 1:59 PM UTC (97c34a1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mse-byte-stream-format-registry/5/1e22f15...97c34a1.html" title="Last updated on Dec 19, 2023, 1:59 PM UTC (97c34a1)">Diff</a>