### PR TITLE
Fix reference to MSE spec

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
 
     <section id="sotd">
       <p>The working group maintains <a href="https://github.com/w3c/mse-byte-stream-format-registry/issues">a list of all bug reports that the editors have not yet tried to address</a>;
-      there may also be related open bugs in the <a href="https://github.com/w3c/media-source">GitHub repository</a> of the [[[MEDIA SOURCE]]] specification.</p>
+      there may also be related open bugs in the <a href="https://github.com/w3c/media-source">GitHub repository</a> of the [[[MEDIA-SOURCE]]] specification.</p>
     </section>
 
     <section id="purpose">


### PR DESCRIPTION
This was causing a ReSpec error.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/mse-byte-stream-format-registry/pull/6.html" title="Last updated on Feb 16, 2024, 4:11 PM UTC (10014d9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mse-byte-stream-format-registry/6/6324325...10014d9.html" title="Last updated on Feb 16, 2024, 4:11 PM UTC (10014d9)">Diff</a>