### PR TITLE
Update registration requirements

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,6 +101,8 @@
       <p>
           The Media Working Group may seek expertise from outside the Working Group as part of its evaluation,
           e.g., from the byte stream format specification editors or relevant standards group.
+          If the byte stream format specification is not publicly available,
+          it must be made available to the Working Group for evaluation.
           For the entry to be included, there needs to be interest from at least one
           implementer in the Working Group.
           If the Media Working Group reaches consensus to accept the candidate,

--- a/index.html
+++ b/index.html
@@ -100,7 +100,7 @@
       </p>
       <p>
           The Media Working Group may seek expertise from outside the Working Group as part of its evaluation,
-          e.g., from the codec specification editors or relevant standards group.
+          e.g., from the byte stream format specification editors or relevant standards group.
           For the entry to be included, there needs to be interest from at least one
           implementer in the Working Group.
           If the Media Working Group reaches consensus to accept the candidate,

--- a/index.html
+++ b/index.html
@@ -93,6 +93,20 @@
 
     <section id="entry-requirements">
       <h2>Registration Entry Requirements</h2>
+      <p>
+        To register an entry, file an issue in the
+        <a href="https://github.com/w3c/mse-byte-stream-format-registry/issues/">Media Source Extensions Byte Stream Format Registry GitHub issue tracker</a>
+        so it can be discussed and evaluated for compliance before being added to the registry.
+      </p>
+      <p>
+          The Media Working Group may seek expertise from outside the Working Group as part of its evaluation,
+          e.g., from the codec specification editors or relevant standards group.
+          For the entry to be included, there needs to be interest from at least one
+          implementer in the Working Group.
+          If the Media Working Group reaches consensus to accept the candidate,
+          send a pull request (either by editors or by the party requesting
+          the candidate registration) that meets the following requirements:
+      </p>
       <ol>
         <li>Each entry must include a unique MIME-type/subtype pair. If the byte stream format is derived-from an existing file format, then it should use the
           MIME-type/subtype pairs typically used for the file format.</li>
@@ -101,18 +115,10 @@
         <li>Each entry must include a link that references a publically available specification. It is recommended that such a specification be made available
           without cost (other than reasonable shipping and handling if not available by online means).</li>
         <li>The referenced specification for each entry must comply with all requirements outlined in the <a data-cite="media-source#byte-stream-formats">Byte Stream Formats section</a> of the [[[MEDIA-SOURCE]]] specification [[MEDIA-SOURCE]].</li>
-        <li>Candidate entries must be announced by filing an issue in the
-          <a href="https://github.com/w3c/mse-byte-stream-format-registry/issues/">Media Source Extensions Byte Stream Format Registry GitHub issue tracker</a>
-          so they can be discussed and evaluated for compliance before being added to the registry.
-          The Media Working Group may seek expertise from outside the Working Group as part of its evaluation,
-          e.g., from the codec specification editors or relevant standards group.
-          If the Media Working Group reaches consensus to accept the candidate,
-          a pull request should be drafted (either by editors or by the party requesting
-          the candidate registration) to register the candidate.
-          The registry editors will review and merge the pull request.</li>
-        <li>If a registration fails to satisfy a mandatory requirement specified above, then it may be removed from the registry (without prejudice). Existing entries cannot be deleted or deprecated otherwise.</li>
-        <li>Existing entries may be changed after being published through the same process as candidate entries. Possible changes include modification of the link to the publically available specification.</li>
       </ol>
+      <p>Once consensus is reached by the Working Group, the registry editors will review and merge the pull request.</p>
+      <p>If a registration fails to satisfy a mandatory requirement specified above, then it may be removed from the registry (without prejudice). Existing entries cannot be deleted or deprecated otherwise.</p>
+      <p>Existing entries may be changed after being published through the same process as candidate entries. Possible changes include modification of the link to the publically available specification.</p>
     </section>
 
     <section id="registry">

--- a/index.html
+++ b/index.html
@@ -119,7 +119,7 @@
         <li>The referenced specification for each entry must comply with all requirements outlined in the <a data-cite="media-source#byte-stream-formats">Byte Stream Formats section</a> of the [[[MEDIA-SOURCE]]] specification [[MEDIA-SOURCE]].</li>
       </ol>
       <p>Once consensus is reached by the Working Group, the registry editors will review and merge the pull request.</p>
-      <p>If a registration fails to satisfy a mandatory requirement specified above, then it may be removed from the registry (without prejudice). Existing entries cannot be deleted or deprecated otherwise.</p>
+      <p>If a registration fails to satisfy a mandatory requirement specified above, then it may be removed from the registry. Existing entries cannot be deleted or deprecated otherwise.</p>
       <p>Existing entries may be changed after being published through the same process as candidate entries. Possible changes include modification of the link to the publically available specification.</p>
     </section>
 


### PR DESCRIPTION
Add requirement for implementer support. We recently made a similar change to the [WebCodecs Codec Registry](https://www.w3.org/TR/webcodecs-codec-registry/), so seems useful to update this registry similarly.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/mse-byte-stream-format-registry/pull/10.html" title="Last updated on Jun 4, 2026, 10:30 AM UTC (1c7a8d0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mse-byte-stream-format-registry/10/990e6a3...1c7a8d0.html" title="Last updated on Jun 4, 2026, 10:30 AM UTC (1c7a8d0)">Diff</a>