### PR TITLE
Refresh registration requirements

### DIFF
--- a/index.html
+++ b/index.html
@@ -129,7 +129,7 @@
         Existing entries may be changed after being published, through the same process as candidate entries. Possible changes include modification of the link to the public specification.
       </p>
       <p>
-        Existing entries cannot be deleted or deprecated.
+        If a registration fails to satisfy a mandatory requirement specified above, then it may be removed from the registry. Existing entries cannot be deleted or deprecated otherwise.
       </p>
     </section>
 

--- a/index.html
+++ b/index.html
@@ -118,7 +118,7 @@
           Each entry must include a {{SourceBuffer/[[generate timestamps flag]]}} value that must be used by {{SourceBuffer}} when handling the byte stream format.
         </li>
         <li>
-          Each entry must include a link that references a publicly available specification.
+          Each entry must include a link that references a publicly available registration specification.
           It is recommended that such a specification be made available without cost (other than reasonable shipping and handling if not available by online means).
         </li>
         <li>

--- a/index.html
+++ b/index.html
@@ -99,6 +99,10 @@
         so it can be discussed and evaluated for compliance before being added to the registry.
       </p>
       <p>
+        The Media Working Group may seek expertise from outside the Working Group as part of its evaluation,
+        e.g., from the editors or relevant standards group of the underlying format specification.
+        If the underlying format specification is not publicly available,
+        it must be made available to the Working Group for evaluation.
         For the entry to be included, there needs to be interest from at least one
         implementer in the Media Working Group.
         If the Media Working Group reaches consensus to accept the candidate,

--- a/index.html
+++ b/index.html
@@ -119,7 +119,9 @@
         </li>
         <li>
           Each entry must include a link that references a publicly available registration specification.
-          It is recommended that such a specification be made available without cost (other than reasonable shipping and handling if not available by online means).
+        </li>
+        <li>
+          It is recommended that the registration specification and the underlying specifications be made available without cost (other than reasonable shipping and handling if not available by online means).
         </li>
         <li>
           The referenced specification for each entry must comply with all requirements outlined in the <a data-cite="media-source#byte-stream-formats">Byte Stream Formats section</a> of the [[[MEDIA-SOURCE]]] specification [[MEDIA-SOURCE]].

--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@
           It is recommended that the registration specification and the underlying specifications be made available without cost (other than reasonable shipping and handling if not available by online means).
         </li>
         <li>
-          The referenced specification for each entry must comply with all requirements outlined in the <a data-cite="media-source#byte-stream-formats">Byte Stream Formats section</a> of the [[[MEDIA-SOURCE]]] specification [[MEDIA-SOURCE]].
+          The registration specification for each entry must comply with all requirements outlined in the <a data-cite="media-source#byte-stream-formats">Byte Stream Formats section</a> of the [[[MEDIA-SOURCE]]] specification [[MEDIA-SOURCE]].
         </li>
       </ol>
       <p>

--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
       #registry table td, table th { border-left: solid; border-right: solid; border-bottom: solid thin; vertical-align: top; padding: 0.2em; }
     </style>
   </head>
-  <body data-cite="media-source">
+  <body data-cite="media-source mimesniff">
 
     <section id="abstract">
       <p>This registry defines the byte stream formats for use with the [[[MEDIA-SOURCE]]] specification [[MEDIA-SOURCE]].</p>
@@ -93,26 +93,44 @@
 
     <section id="entry-requirements">
       <h2>Registration Entry Requirements</h2>
+      <p>
+        To register an entry, file an issue in the
+        <a href="https://github.com/w3c/mse-byte-stream-format-registry/issues/">Media Source Extensions Byte Stream Format Registry GitHub issue tracker</a>
+        so it can be discussed and evaluated for compliance before being added to the registry.
+      </p>
+      <p>
+        For the entry to be included, there needs to be interest from at least one
+        implementer in the Media Working Group.
+        If the Media Working Group reaches consensus to accept the candidate,
+        send a pull request (either by the registry editors or by the party requesting
+        the candidate registration) to register the candidate
+        that meets the following requirements:
+      </p>
       <ol>
-        <li>Each entry must include a unique MIME-type/subtype pair. If the byte stream format is derived-from an existing file format, then it should use the
-          MIME-type/subtype pairs typically used for the file format.</li>
-        <li>Each entry must include a {{SourceBuffer/[[generate timestamps flag]]}} value that must be used by
-            {{SourceBuffer}} when handling the byte stream format.</li>
-        <li>Each entry must include a link that references a publically available specification. It is recommended that such a specification be made available
-          without cost (other than reasonable shipping and handling if not available by online means).</li>
-        <li>The referenced specification for each entry must comply with all requirements outlined in the <a data-cite="media-source#byte-stream-formats">Byte Stream Formats section</a> of the [[[MEDIA-SOURCE]]] specification [[MEDIA-SOURCE]].</li>
-        <li>Candidate entries must be announced by filing an issue in the
-          <a href="https://github.com/w3c/mse-byte-stream-format-registry/issues/">Media Source Extensions Byte Stream Format Registry GitHub issue tracker</a>
-          so they can be discussed and evaluated for compliance before being added to the registry.
-          The Media Working Group may seek expertise from outside the Working Group as part of its evaluation,
-          e.g., from the codec specification editors or relevant standards group.
-          If the Media Working Group reaches consensus to accept the candidate,
-          a pull request should be drafted (either by editors or by the party requesting
-          the candidate registration) to register the candidate.
-          The registry editors will review and merge the pull request.</li>
-        <li>If a registration fails to satisfy a mandatory requirement specified above, then it may be removed from the registry (without prejudice). Existing entries cannot be deleted or deprecated otherwise.</li>
-        <li>Existing entries may be changed after being published through the same process as candidate entries. Possible changes include modification of the link to the publically available specification.</li>
+        <li>
+          Each entry must include a unique [=MIME type=]/[=MIME type/subtype=] pair. If the byte stream format is derived-from an existing file format, then it should use the [=MIME type=]/[=MIME type/subtype=] pairs typically used for the file format.
+        </li>
+        <li>
+          Each entry must include a {{SourceBuffer/[[generate timestamps flag]]}} value that must be used by {{SourceBuffer}} when handling the byte stream format.
+        </li>
+        <li>
+          Each entry must include a link that references a publicly available specification.
+          It is recommended that such a specification be made available without cost (other than reasonable shipping and handling if not available by online means).
+        </li>
+        <li>
+          The referenced specification for each entry must comply with all requirements outlined in the <a data-cite="media-source#byte-stream-formats">Byte Stream Formats section</a> of the [[[MEDIA-SOURCE]]] specification [[MEDIA-SOURCE]].
+        </li>
       </ol>
+      <p>
+        Once consensus is reached by the Working Group,
+        the registry editors will review and merge the pull request.
+      </p>
+      <p>
+        Existing entries may be changed after being published, through the same process as candidate entries. Possible changes include modification of the link to the public specification.
+      </p>
+      <p>
+        Existing entries cannot be deleted or deprecated.
+      </p>
     </section>
 
     <section id="registry">

--- a/index.html
+++ b/index.html
@@ -121,10 +121,10 @@
           Each entry must include a link that references a publicly available registration specification.
         </li>
         <li>
-          It is recommended that the registration specification and the underlying specifications be made available without cost (other than reasonable shipping and handling if not available by online means).
+          The registration specification for each entry must comply with all requirements outlined in the <a data-cite="media-source#byte-stream-formats">Byte Stream Formats section</a> of the [[[MEDIA-SOURCE]]] specification [[MEDIA-SOURCE]].
         </li>
         <li>
-          The registration specification for each entry must comply with all requirements outlined in the <a data-cite="media-source#byte-stream-formats">Byte Stream Formats section</a> of the [[[MEDIA-SOURCE]]] specification [[MEDIA-SOURCE]].
+          It is recommended that the registration specification and the underlying specifications be made available without cost (other than reasonable shipping and handling if not available by online means).
         </li>
       </ol>
       <p>


### PR DESCRIPTION
This applies the same changes as made in the past few months in other draft registries published by the Media Working Group to clarify registration requirements:
https://www.w3.org/groups/wg/media/publications/#dry


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/mse-byte-stream-format-registry/pull/11.html" title="Last updated on Jun 4, 2026, 11:00 AM UTC (2215a82)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mse-byte-stream-format-registry/11/990e6a3...2215a82.html" title="Last updated on Jun 4, 2026, 11:00 AM UTC (2215a82)">Diff</a>